### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ $(BUILD_DIR)/all-linked.txt: FORCE
 		--snakefile workflow/link_runs.smk
 
 $(BUILD_DIR)/%: FORCE
-	snakemake $(PROFILE) $(CFG) $@
+	snakemake $(PROFILE) $@ $(CFG)
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)


### PR DESCRIPTION
Got an error when calling `make something`, as the pattern rule would expand to 
```
snakemake --config var=value something
```
which fails as `something` is not the correct syntax for configuration.