### PR TITLE
Map IRFs with sin(delta) and cos(zenith)

### DIFF
--- a/link-paths.py
+++ b/link-paths.py
@@ -47,6 +47,12 @@ template_linkname_model = outdir_model.resolve().as_posix()
 
 def sin_delta(altaz: AltAz):
     """Delta is the angle between pointing and magnetic field."""
+    # Values from
+    # https://geomag.bgs.ac.uk/data_service/models_compass/igrf_calc.html
+    # for La Palma coordinates and date=2021-12-01.
+    #
+    # Also used here:
+    # https://github.com/cta-observatory/lst-sim-config/issues/2
     b_inc = u.Quantity(-37.36, u.deg)
     b_dec = u.Quantity(-4.84, u.deg)
 
@@ -127,8 +133,8 @@ def main() -> None:
     filelist = [p.name for p in path.parent.iterdir()]
     irf_pointings: AltAz = get_pointings_of_irfs(filelist)
 
-    irf_sin_delta = sin_delta(irf_pointings)
-    irf_cos_zenith = cos_zenith(irf_pointings)
+    irf_sindelta = sin_delta(irf_pointings)
+    irf_coszenith = cos_zenith(irf_pointings)
 
     progress = tqdm(total=n_runs)
 
@@ -148,8 +154,8 @@ def main() -> None:
             nearest_irf = euclidean_distance(
                 x1=sindelta,
                 y1=coszenith,
-                x2=irf_sin_delta,
-                y2=irf_cos_zenith,
+                x2=irf_sindelta,
+                y2=irf_coszenith,
             ).argmin()
             node = filelist[nearest_irf]
 


### PR DESCRIPTION
This PR intends to change the mapping of the nearest IRF from angular separation of AltAz to the Euclidean distance of sin(delta) and cos(zenith), where delta is the angular separation of the magnetic field and the pointing; thereby, this fixes #46.

Additional (planned) changes:

- [x] if the link exists, remove it and link again (to overwrite). This was needed to link the new nearest files.
- [ ] remove IRF template/linkname. We don't link IRFs, we calculate them from Test DL2 Gammas
- [ ] don't link one model per run_id. That is a remnant from when we wanted to analyze many sources. In the present case we use *one* model (from the configured declination line) per `config_dir`, e.g. per source.  The snakemake workflow should be able to link the one model.
- [ ] I also think that the Snakefile can handle the linking/assignment of nearest nodes (DL2 files), after creating `runs.json`. I'm not sure though whether that is a good call.

Edit: decided to not go for the other points, let's keep PRs small and tidy.