### PR TITLE
Allow runs to be explicitly white- or blacklisted

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -63,8 +63,8 @@ class Config(BaseModel):
     time_start: Optional[TimeType]
     time_stop: Optional[TimeType]
 
-    whitelisted_runs: List[int] = []
-    blacklisted_runs: List[int] = []
+    always_include: List[int] = []
+    never_include: List[int] = []
 
     _val_time_start = validator("time_start", allow_reuse=True, pre=True)(ll_or_inf)
     _val_time_stop = validator("time_stop", allow_reuse=True, pre=True)(ul_or_inf)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 from astropy.time import Time
@@ -62,6 +62,9 @@ class Config(BaseModel):
 
     time_start: Optional[TimeType]
     time_stop: Optional[TimeType]
+
+    whitelisted_runs: List[int]
+    blacklisted_runs: List[int]
 
     _val_time_start = validator("time_start", allow_reuse=True, pre=True)(ll_or_inf)
     _val_time_stop = validator("time_stop", allow_reuse=True, pre=True)(ul_or_inf)

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -63,8 +63,8 @@ class Config(BaseModel):
     time_start: Optional[TimeType]
     time_stop: Optional[TimeType]
 
-    whitelisted_runs: List[int]
-    blacklisted_runs: List[int]
+    whitelisted_runs: List[int] = []
+    blacklisted_runs: List[int] = []
 
     _val_time_start = validator("time_start", allow_reuse=True, pre=True)(ll_or_inf)
     _val_time_stop = validator("time_stop", allow_reuse=True, pre=True)(ul_or_inf)

--- a/scripts/data-check.py
+++ b/scripts/data-check.py
@@ -249,8 +249,8 @@ if __name__ == "__main__":
     mask = np.in1d(run_ids, runsummary["runnumber"][mask])
     log.info(f"Selected runs after cuts: {run_ids[mask]}")
 
-    mask = mask | np.isin(run_ids, config.whitelisted_runs)
-    mask = mask & (~np.isin(run_ids, config.blacklisted_runs))
+    mask = mask | np.isin(run_ids, config.always_include)
+    mask = mask & (~np.isin(run_ids, config.never_include))
     log.info(f"Selected runs after checking whitelist/blacklist: {run_ids[mask]}")
 
     runs[mask].to_csv(args.output_runlist, index=False)

--- a/scripts/data-check.py
+++ b/scripts/data-check.py
@@ -247,6 +247,11 @@ if __name__ == "__main__":
     log.info(s)
 
     mask = np.in1d(run_ids, runsummary["runnumber"][mask])
+    log.info(f"Selected runs after cuts: {run_ids[mask]}")
+
+    mask = mask | np.isin(run_ids, config.whitelisted_runs)
+    mask = mask & (~np.isin(run_ids, config.blacklisted_runs))
+    log.info(f"Selected runs after checking whitelist/blacklist: {run_ids[mask]}")
 
     runs[mask].to_csv(args.output_runlist, index=False)
 


### PR DESCRIPTION
This effectively overrules the run selection based on pedestals etc
Might be handy sometimes if we know a run is for sure broken, but our selection does not reflect that.