### PR TITLE
use squeue for snakemake/slurm status checks

### DIFF
--- a/workflow/profiles/slurm/config.yaml
+++ b/workflow/profiles/slurm/config.yaml
@@ -27,4 +27,4 @@ printshellcmds: True
 scheduler: greedy
 use-conda: True
 cluster-cancel: scancel
-cluster-status: status-sacct.sh
+cluster-status: status-squeue.sh

--- a/workflow/profiles/slurm/status-squeue.sh
+++ b/workflow/profiles/slurm/status-squeue.sh
@@ -13,12 +13,10 @@ fi
 
 output=`squeue --me -j "$jobid" -o '%T' -h`
 
-if [[ $output =~ ^(COMPLETED).* ]]
-then
-  echo success
-elif [[ $output =~ ^(RUNNING|PENDING|COMPLETING|CONFIGURING|SUSPENDED).* ]]
+# Failure is not an option
+if [[ -n $output ]]
 then
   echo running
 else
-  echo failed
+  echo success
 fi

--- a/workflow/profiles/slurm/status-squeue.sh
+++ b/workflow/profiles/slurm/status-squeue.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Check status of Slurm job
+
+jobid="$1"
+
+if [[ "$jobid" == Submitted ]]
+then
+  echo smk-simple-slurm: Invalid job ID: "$jobid" >&2
+  echo smk-simple-slurm: Did you remember to add the flag --parsable to your sbatch call? >&2
+  exit 1
+fi
+
+output=`squeue --me -j "$jobid" -o '%T' -h`
+
+if [[ $output =~ ^(COMPLETED).* ]]
+then
+  echo success
+elif [[ $output =~ ^(RUNNING|PENDING|COMPLETING|CONFIGURING|SUSPENDED).* ]]
+then
+  echo running
+else
+  echo failed
+fi


### PR DESCRIPTION
This uses `squeue` instead of `sacct` for the status checks.

Needs to be tested though